### PR TITLE
Follow rack conventions on Host and Port options

### DIFF
--- a/lib/rack/handler/reel.rb
+++ b/lib/rack/handler/reel.rb
@@ -4,8 +4,8 @@ module Rack
   module Handler
     class Reel
       DEFAULT_OPTIONS = {
-        :host    => "0.0.0.0",
-        :port    => 3000,
+        :Host    => "0.0.0.0",
+        :Port    => 3000,
         :quiet   => false
       }
 

--- a/lib/reel/rack/cli.rb
+++ b/lib/reel/rack/cli.rb
@@ -8,7 +8,7 @@ module Reel
         @argv   = argv
         @options = {
           addr:   "localhost",
-          port:   3000,
+          Port:   3000,
           quiet:  false,
           rackup: "config.ru"
         }
@@ -23,8 +23,8 @@ module Reel
             @options[:addr] = addr
           end
 
-          o.on "-p", "--port PORT", "Port to bind to (default #{@options[:port]})" do |port|
-            @options[:port] = port
+          o.on "-p", "--port PORT", "Port to bind to (default #{@options[:Port]})" do |port|
+            @options[:Port] = port
           end
 
           o.on "-q", "--quiet", "Suppress normal logging output" do

--- a/lib/reel/rack/server.rb
+++ b/lib/reel/rack/server.rb
@@ -1,4 +1,3 @@
-
 # Adapted from code orinially Copyright (c) 2013 Jonathan Stott
 
 require 'reel'
@@ -12,13 +11,13 @@ module Reel
       attr_reader :app
 
       def initialize(app, options)
-        raise ArgumentError, "no host given" unless options[:host]
-        raise ArgumentError, "no port given" unless options[:port]
+        raise ArgumentError, "no host given" unless options[:Host]
+        raise ArgumentError, "no port given" unless options[:Port]
 
         info  "A Reel good HTTP server! (Codename \"#{::Reel::CODENAME}\")"
-        info "Listening on http://#{options[:host]}:#{options[:port]}"
+        info "Listening on http://#{options[:Host]}:#{options[:Port]}"
 
-        super(options[:host], options[:port], &method(:on_connection))
+        super(options[:Host], options[:Port], &method(:on_connection))
         @app = app
       end
    

--- a/spec/reel/rack/server_spec.rb
+++ b/spec/reel/rack/server_spec.rb
@@ -1,4 +1,3 @@
-
 require 'spec_helper'
 require 'net/http'
 
@@ -9,7 +8,7 @@ describe Reel::Rack::Server do
 
   subject do
     app = proc { [200, {"Content-Type" => "text/plain"}, body] }
-    described_class.new(app, :host => host, :port => port)
+    described_class.new(app, :Host => host, :Port => port)
   end
 
   it "runs a basic Hello World app" do


### PR DESCRIPTION
Rack conventions for naming host and port options are `:Host` and `:Port` instead of `:host` and `:port`. This thing came up in a discussion to add reel-rack support to sinatra (please see sinatra/sinatra#793).

Thanks!
