### PR TITLE
construct full url to pass to MockRequest#env_for

### DIFF
--- a/lib/reel/rack/server.rb
+++ b/lib/reel/rack/server.rb
@@ -37,8 +37,12 @@ module Reel
           :input        => request.body.to_s,
           "REMOTE_ADDR" => request.remote_addr
         }.merge(convert_headers(request.headers))
-   
-        status, headers, body = app.call ::Rack::MockRequest.env_for(request.url, options)
+
+        # Construct full url so that rack can generate a correct environment.
+        # see https://github.com/rack/rack/blob/master/lib/rack/mock.rb.
+        url = "http://#{request.headers['Host']}#{request.url}"
+
+        status, headers, body = app.call ::Rack::MockRequest.env_for(url, options)
 
         if body.respond_to?(:to_str)
           request.respond status_symbol(status), headers, body.to_str


### PR DESCRIPTION
I came accross issue #5 while testing reel with rack urlmap. It's not working because `SERVER_NAME` and `SERVER_PORT` do not get set correctly (see https://github.com/rack/rack/blob/master/lib/rack/mock.rb#L88).

I modified this so that a more complete url is passed to `env_for`. I don't know if it's the right way to go.
- I'm still missing the scheme (just picking http for now)
- Maybe `Reel::Request#url` should return a full url?

What do you think?
