### PR TITLE
Initial websocket support

### DIFF
--- a/lib/reel/rack/server.rb
+++ b/lib/reel/rack/server.rb
@@ -23,27 +23,25 @@ module Reel
    
       def on_connection(connection)
         connection.each_request do |request|
-          if request.websocket?
-            request.respond :bad_request, "WebSockets not supported"
-          else
-            route_request request
-          end
+          route_request request, connection
         end
       end
    
       # Compile the regex once
       CONTENT_LENGTH_HEADER = %r{^content-length$}i
 
-      def route_request(request)
+      def route_request(request, connection)
         options = {
-          :method       => request.method,
-          :input        => request.body.to_s,
-          "REMOTE_ADDR" => request.remote_addr
+          :method        => request.method,
+          :input         => request.body.to_s,
+          "REMOTE_ADDR"  => request.remote_addr,
+          "reel.request" => request
         }.merge(convert_headers(request.headers))
 
         normalize_env(options)
 
         status, headers, body = app.call ::Rack::MockRequest.env_for(request.url, options)
+        return if connection.response_state == :hijacked
 
         if body.respond_to? :each
           # If Content-Length was specified we can send the response all at once


### PR DESCRIPTION
This adds initial websocket support.  It is not complete yet as while
you can create a websocket and send data via the websocket, receiving
data from the websocket does not work, for reasons I've yet to
determine.

This changes the API for route_request, because Reel::Request#connection
is not defined. It includes the request object in a 'reel.request' entry
in the env, so that rack apps can do:

  ws = env['reel.request'].websocket if env['reel.request'].websocket?

If anyone could provide a pointer to why receiving data via the websocket
may not be working, that would be helpful.